### PR TITLE
Correct postgres port while running postgres for clair

### DIFF
--- a/modules/clair-standalone-configure.adoc
+++ b/modules/clair-standalone-configure.adoc
@@ -33,7 +33,7 @@ $ sudo podman run -d --name postgresql-clairv4 \
   -e POSTGRESQL_PASSWORD=clairpass \
   -e POSTGRESQL_DATABASE=clair \
   -e POSTGRESQL_ADMIN_PASSWORD=adminpass \
-  -p 5433:5433 \
+  -p 5433:5432 \
   -v /home/<user-name>/quay-poc/postgres-clairv4:/var/lib/pgsql/data:Z \
   registry.redhat.io/rhel8/postgresql-13:1-109
 ----


### PR DESCRIPTION
As the standard Postgres port, 5432, is already in use by the Quay deployment, expose a different port in this instance 5433 but the container target port remains 5432.